### PR TITLE
bcftools 1.3.1 recipe

### DIFF
--- a/bcftools-1.3.1/Dockerfile
+++ b/bcftools-1.3.1/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:14.04
+MAINTAINER Indraniel Das <idas@wustl.edu>
+
+# Volumes
+VOLUME /build
+VOLUME /release
+
+# bootstrap build dependencies
+RUN apt-get update -qq && \
+    apt-get -y install apt-transport-https && \
+    apt-get update -qq && \
+    apt-get -y install \
+    build-essential \
+    debhelper \
+    bzip2 \
+    libcurl4-openssl-dev \
+    ca-certificates \
+    curl \
+    zlib1g \
+    zlib1g-dev \
+    --no-install-recommends
+
+WORKDIR /build
+
+# Import resources
+COPY ./Makefile /build
+
+CMD make

--- a/bcftools-1.3.1/Makefile
+++ b/bcftools-1.3.1/Makefile
@@ -66,6 +66,7 @@ fi
 endef
 export debian_postrm
 
+# BCFTOOLS EXECUTABLE DEBIAN WRAPPER ###########################################################
 define bcftools_wrapper
 #!/bin/bash
 

--- a/bcftools-1.3.1/Makefile
+++ b/bcftools-1.3.1/Makefile
@@ -1,0 +1,145 @@
+.PHONY: clean debian debclean
+
+# external commands used
+CURL  := /usr/bin/curl
+TAR   := /bin/tar
+CP    := /bin/cp
+RM    := /bin/rm
+MV    := /bin/mv
+MKDIR := /bin/mkdir
+ECHO  := /bin/echo
+AR    := /usr/bin/ar
+TEST  := /usr/bin/test
+
+# basic workspace directories
+WORK_DIR         := /build
+BASE_INSTALL_DIR := $(WORK_DIR)
+RESOURCES_DIR    := $(WORK_DIR)/resources
+RELEASE_DIR      := /release
+
+# source code information
+BCFTOOLS_VERSION    := 1.3.1
+BCFTOOLS_URL        := https://github.com/samtools/bcftools/releases/download/$(BCFTOOLS_VERSION)/bcftools-$(BCFTOOLS_VERSION).tar.bz2
+BCFTOOLS_ZIP        := $(RESOURCES_DIR)/bcftools-$(BCFTOOLS_VERSION).tar.bz2
+BCFTOOLS_OUTPUT_DIR := $(WORK_DIR)/bcftools-1.3.1
+BCFTOOLS            := $(WORK_DIR)/bin/bcftools
+
+# source code information
+HTSLIB_VERSION    := 1.3.2
+HTSLIB_URL        := https://github.com/samtools/htslib/releases/download/$(HTSLIB_VERSION)/htslib-$(HTSLIB_VERSION).tar.bz2
+HTSLIB_ZIP        := $(RESOURCES_DIR)/htslib-$(HTSLIB_VERSION).tar.bz2
+HTSLIB_OUTPUT_DIR := $(WORK_DIR)/htslib-1.3.2
+TABIX             := $(WORK_DIR)/bin/tabix
+BGZIP             := $(WORK_DIR)/bin/bgzip
+
+# debian packaging related variables
+DEB_BUILD_DIR       := $(WORK_DIR)/deb-build
+UBUNTU_EDITION      := $(shell . /etc/lsb-release; $(ECHO) $$DISTRIB_RELEASE)
+DEB_RELEASE_VERSION := 1ubuntu$(UBUNTU_EDITION)
+DEB_PKG             := ccdg-bcftools-$(BCFTOOLS_VERSION)_$(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION).deb
+DEB_PKG_PATH        := $(RELEASE_DIR)/$(DEB_PKG)
+DEB_BASE_INSTALL    := /opt/ccdg/bcftools-$(BCFTOOLS_VERSION)
+
+# DEBIAN CONTROL FILE ##########################################################
+define debian_control
+Package: ccdg-bcftools-$(BCFTOOLS_VERSION)
+Architecture: amd64
+Section: science
+Maintainer: Indraniel Das <idas@wustl.edu>
+Priority: optional
+Depends: libc6, libcurl3, zlib1g, ca-certificates
+Description: bcftools-$(BCFTOOLS_VERSION) plus htslib-$(HTSLIB_VERSION) for the CCDG pipeline
+Version: $(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION)
+endef
+export debian_control
+
+# DEBIAN POSTRM FILE ###########################################################
+define debian_postrm
+#!/bin/bash
+
+BASE=$(DEB_BASE_INSTALL)
+
+if [ -e $${BASE} ]; then
+    $(RM) -rfv $${BASE}
+fi
+
+endef
+export debian_postrm
+
+define bcftools_wrapper
+#!/bin/bash
+
+BASE=$(DEB_BASE_INSTALL)
+BCFTOOLS_PLUGINS=$${BCFTOOLS_PLUGINS:-$(DEB_BASE_INSTALL)/libexec/bcftools}
+export BCFTOOLS_PLUGINS
+
+exec $${BASE}/bin/bcftools-$(BCFTOOLS_VERSION) "$$@"
+endef
+export bcftools_wrapper
+
+all: debian
+
+debian: | $(BCFTOOLS)
+	# setup the directory
+	$(TEST) -d $(DEB_BUILD_DIR) || $(MKDIR) $(DEB_BUILD_DIR)
+	
+	# setup the debian package meta information
+	$(ECHO) "$$debian_postrm" > $(DEB_BUILD_DIR)/postrm
+	$(ECHO) "$$debian_control" > $(DEB_BUILD_DIR)/control
+	$(ECHO) 2.0 > $(DEB_BUILD_DIR)/debian-binary
+	
+	# create the "installed" file directory structure
+	$(MKDIR) -p $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+
+	$(CP) -rv $(BASE_INSTALL_DIR)/bin $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/include $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/lib $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/share $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/libexec $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+
+	# wrapper script to set bcftools plugin environment variable
+	echo "$$bcftools_wrapper" > $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
+	chmod a+x $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
+	
+	# create the underlying tars of the debian package
+	$(TAR) cvzf $(DEB_BUILD_DIR)/data.tar.gz --owner=0 --group=0 -C $(DEB_BUILD_DIR) opt
+	$(TAR) cvzf $(DEB_BUILD_DIR)/control.tar.gz -C $(DEB_BUILD_DIR) control postrm
+	
+	# assemble the formal "deb" package
+	cd $(DEB_BUILD_DIR) && \
+		$(AR) rc $(DEB_PKG) debian-binary control.tar.gz data.tar.gz && \
+		$(MV) $(DEB_PKG) $(RELEASE_DIR)
+
+$(BCFTOOLS): $(BCFTOOLS_ZIP) $(TABIX) $(BGZIP)
+	$(TAR) -jxvf $(BCFTOOLS_ZIP) \
+		&& cd $(BCFTOOLS_OUTPUT_DIR) \
+		&& make all HTSDIR=$(HTSLIB_OUTPUT_DIR) prefix="$(BASE_INSTALL_DIR)" LIBS="-lcurl -lcrypto -lssl" \
+		&& make install HTSDIR=$(HTSLIB_OUTPUT_DIR) prefix="$(BASE_INSTALL_DIR)" LIBS="-lcurl -lcrypto -lssl" \
+		&& $(MV) $(BCFTOOLS) $(BCFTOOLS)-$(BCFTOOLS_VERSION)
+
+$(BCFTOOLS_ZIP):
+	mkdir -p $(RESOURCES_DIR)
+	cd $(RESOURCES_DIR) && \
+		$(CURL) -L -O $(BCFTOOLS_URL)
+
+$(TABIX) $(BGZIP): $(HTSLIB_ZIP)
+	$(TAR) -jxvf $(HTSLIB_ZIP) \
+		&& cd $(HTSLIB_OUTPUT_DIR) \
+		&& ./configure --enable-libcurl --prefix=$(BASE_INSTALL_DIR) \
+		&& make lib-static \
+		&& make install
+
+$(HTSLIB_ZIP):
+	mkdir -p $(RESOURCES_DIR)
+	cd $(RESOURCES_DIR) && \
+		$(CURL) -L -O $(HTSLIB_URL)
+
+debclean:
+	if [ -e $(DEB_BUILD_DIR) ]; then $(RM) -rf $(DEB_BUILD_DIR); fi
+	if [ -e $(DEB_PKG_PATH) ]; then $(RM) -rf $(DEB_PKG_PATH); fi
+
+clean:
+	if [ -e $(BCFTOOLS_OUTPUT_DIR) ]; then $(RM) -rf $(BCFTOOLS_OUTPUT_DIR); fi
+	if [ -e $(HTSLIB_OUTPUT_DIR) ]; then $(RM) -rf $(HTSLIB_OUTPUT_DIR); fi
+	if [ -e $(DEB_BUILD_DIR) ]; then $(RM) -rf $(DEB_BUILD_DIR); fi
+	if [ -e $(DEB_PKG_PATH) ]; then $(RM) -rf $(DEB_PKG_PATH); fi

--- a/bcftools-1.3.1/README.md
+++ b/bcftools-1.3.1/README.md
@@ -1,0 +1,21 @@
+# production mode
+
+    docker build -t bcftools-1.3.1:v1 .
+    docker run -i -t -v $PWD:/release --rm bcftools-1.3.1:v1
+
+# Development Mode
+
+comment out the "COPY" commands in the Dockerfile, and then run:
+
+    docker build -t bcftools-1.3.1:v1 .
+    docker run -i -t -v $PWD:/build --rm bcftools-1.3.1:v1 bash
+
+# Testing
+
+    docker build -t bcftools-1.3.1:v1 .
+    docker run -i -t -v $PWD:/release --rm bcftools-1.3.1:v1 bash
+
+    # inside the container
+    cd /release
+    # manually install the prerequisites for the package
+    dpkg --install ccdg-bcftools-1.3.1_1.3.1-1ubuntu14.04.deb


### PR DESCRIPTION
bcftools1.3.1 recipe. Doesn't include dependencies for plotting (i.e. latex, python, perl and matplotlib)