### PR TITLE
Bcftools 1.9

### DIFF
--- a/bcftools-1.9/Dockerfile
+++ b/bcftools-1.9/Dockerfile
@@ -1,15 +1,21 @@
 FROM debian:stretch-slim
-MAINTAINER Indraniel Das <idas@wustl.edu>
+label maintainer "Dave Larson <delarson@wustl.edu>"
 
 # Volumes
 VOLUME /build
 VOLUME /release
 
+COPY hall-lab-htslib-1.9_1.9-1debian9.5.deb .
+
 # bootstrap build dependencies
 RUN apt-get update -qq && \
-    apt-get -y install apt-transport-https && \
+    apt-get -y install apt-transport-https curl && \
+    #apt-get -y install apt-transport-https curl gnupg && \
+    #echo "deb https://packages.cloud.google.com/apt cloud-sdk-trusty main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    #curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update -qq && \
     apt-get -y install \
+    #google-cloud-sdk \
     build-essential \
     debhelper \
     bzip2 \
@@ -21,11 +27,18 @@ RUN apt-get update -qq && \
     curl \
     zlib1g \
     zlib1g-dev \
-    --no-install-recommends
+    --no-install-recommends && \
+    #gsutil cp gs://mgi-ccdg-sw/bootstrap/gs . && \
+    #chmod 0755 gs && \
+    #mv -v gs /usr/lib/apt/methods && \
+    #echo "deb [trusted=yes] gs://mgi-ccdg-sw/apt stretch main" | tee -a /etc/apt/sources.list && \
+    #apt-get update -qq && \
+    #apt-get install hall-lab-htslib-1.9
+    dpkg --install hall-lab-htslib-1.9_1.9-1debian9.5.deb
 
 WORKDIR /build
 
 # Import resources
-#COPY ./Makefile /build
+COPY ./Makefile /build
 
 CMD make

--- a/bcftools-1.9/Dockerfile
+++ b/bcftools-1.9/Dockerfile
@@ -2,43 +2,40 @@ FROM debian:stretch-slim
 label maintainer "Dave Larson <delarson@wustl.edu>"
 
 # Volumes
-VOLUME /build
+#VOLUME /build
 VOLUME /release
 
-COPY hall-lab-htslib-1.9_1.9-1debian9.5.deb .
+ARG LIBDEFLATE_VERSION=1.0
 
 # bootstrap build dependencies
 RUN apt-get update -qq && \
     apt-get -y install apt-transport-https curl && \
-    #apt-get -y install apt-transport-https curl gnupg && \
-    #echo "deb https://packages.cloud.google.com/apt cloud-sdk-trusty main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    #curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update -qq && \
     apt-get -y install \
-    #google-cloud-sdk \
     build-essential \
+    git-core \
     debhelper \
     bzip2 \
     libbz2-dev \
     liblzma-dev \
-    libssl-dev \
+    libssl1.0-dev \
     libcurl4-openssl-dev \
     ca-certificates \
     curl \
     zlib1g \
     zlib1g-dev \
-    --no-install-recommends && \
-    #gsutil cp gs://mgi-ccdg-sw/bootstrap/gs . && \
-    #chmod 0755 gs && \
-    #mv -v gs /usr/lib/apt/methods && \
-    #echo "deb [trusted=yes] gs://mgi-ccdg-sw/apt stretch main" | tee -a /etc/apt/sources.list && \
-    #apt-get update -qq && \
-    #apt-get install hall-lab-htslib-1.9
-    dpkg --install hall-lab-htslib-1.9_1.9-1debian9.5.deb
+    --no-install-recommends \
+    && git clone https://github.com/ebiggers/libdeflate.git \
+    && cd libdeflate \
+    && git checkout v${LIBDEFLATE_VERSION} \
+    && make -j 2 CFLAGS='-fPIC -O3' libdeflate.a \
+    && install -Dm644 -t /usr/local/lib libdeflate.a \
+    && install -Dm644 -t /usr/local/include libdeflate.h
 
 WORKDIR /build
 
 # Import resources
 COPY ./Makefile /build
+RUN make debian-build
 
 CMD make

--- a/bcftools-1.9/Dockerfile
+++ b/bcftools-1.9/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:stretch-slim
+MAINTAINER Indraniel Das <idas@wustl.edu>
+
+# Volumes
+VOLUME /build
+VOLUME /release
+
+# bootstrap build dependencies
+RUN apt-get update -qq && \
+    apt-get -y install apt-transport-https && \
+    apt-get update -qq && \
+    apt-get -y install \
+    build-essential \
+    debhelper \
+    bzip2 \
+    libbz2-dev \
+    liblzma-dev \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    ca-certificates \
+    curl \
+    zlib1g \
+    zlib1g-dev \
+    --no-install-recommends
+
+WORKDIR /build
+
+# Import resources
+#COPY ./Makefile /build
+
+CMD make

--- a/bcftools-1.9/Makefile
+++ b/bcftools-1.9/Makefile
@@ -1,0 +1,146 @@
+.PHONY: clean debian debclean
+
+# external commands used
+CURL  := /usr/bin/curl
+TAR   := /bin/tar
+CP    := /bin/cp
+RM    := /bin/rm
+MV    := /bin/mv
+MKDIR := /bin/mkdir
+ECHO  := /bin/echo
+AR    := /usr/bin/ar
+TEST  := /usr/bin/test
+
+# basic workspace directories
+WORK_DIR         := /build
+BASE_INSTALL_DIR := $(WORK_DIR)
+RESOURCES_DIR    := $(WORK_DIR)/resources
+RELEASE_DIR      := /release
+
+# source code information
+BCFTOOLS_VERSION    := 1.9
+BCFTOOLS_URL        := https://github.com/samtools/bcftools/releases/download/$(BCFTOOLS_VERSION)/bcftools-$(BCFTOOLS_VERSION).tar.bz2
+BCFTOOLS_ZIP        := $(RESOURCES_DIR)/bcftools-$(BCFTOOLS_VERSION).tar.bz2
+BCFTOOLS_OUTPUT_DIR := $(WORK_DIR)/bcftools-$(BCFTOOLS_VERSION)
+BCFTOOLS            := $(WORK_DIR)/bin/bcftools
+
+# source code information
+HTSLIB_VERSION    := 1.9
+HTSLIB_URL        := https://github.com/samtools/htslib/releases/download/$(HTSLIB_VERSION)/htslib-$(HTSLIB_VERSION).tar.bz2
+HTSLIB_ZIP        := $(RESOURCES_DIR)/htslib-$(HTSLIB_VERSION).tar.bz2
+HTSLIB_OUTPUT_DIR := $(WORK_DIR)/htslib-$(HTSLIB_VERSION)
+TABIX             := $(WORK_DIR)/bin/tabix
+BGZIP             := $(WORK_DIR)/bin/bgzip
+
+# debian packaging related variables
+DEB_BUILD_DIR       := $(WORK_DIR)/deb-build
+DEBIAN_EDITION      := $(shell cat /etc/debian_version)
+DEB_RELEASE_VERSION := 1debian$(DEBIAN_EDITION)
+DEB_PKG             := hall-lab-bcftools-$(BCFTOOLS_VERSION)_$(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION).deb
+DEB_PKG_PATH        := $(RELEASE_DIR)/$(DEB_PKG)
+DEB_BASE_INSTALL    := /opt/hall-lab/bcftools-$(BCFTOOLS_VERSION)
+
+# DEBIAN CONTROL FILE ##########################################################
+define debian_control
+Package: hall-lab-bcftools-$(BCFTOOLS_VERSION)
+Architecture: amd64
+Section: science
+Maintainer: Indraniel Das <idas@wustl.edu>
+Priority: optional
+Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.1
+Description: bcftools-$(BCFTOOLS_VERSION) plus htslib-$(HTSLIB_VERSION) for the Hall Lab 
+Version: $(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION)
+endef
+export debian_control
+
+# DEBIAN POSTRM FILE ###########################################################
+define debian_postrm
+#!/bin/bash
+
+BASE=$(DEB_BASE_INSTALL)
+
+if [ -e $${BASE} ]; then
+    $(RM) -rfv $${BASE}
+fi
+
+endef
+export debian_postrm
+
+# BCFTOOLS EXECUTABLE DEBIAN WRAPPER ###########################################################
+define bcftools_wrapper
+#!/bin/bash
+
+BASE=$(DEB_BASE_INSTALL)
+BCFTOOLS_PLUGINS=$${BCFTOOLS_PLUGINS:-$(DEB_BASE_INSTALL)/libexec/bcftools}
+export BCFTOOLS_PLUGINS
+
+exec $${BASE}/bin/bcftools-$(BCFTOOLS_VERSION) "$$@"
+endef
+export bcftools_wrapper
+
+all: debian
+
+debian: | $(BCFTOOLS)
+	# setup the directory
+	$(TEST) -d $(DEB_BUILD_DIR) || $(MKDIR) $(DEB_BUILD_DIR)
+	
+	# setup the debian package meta information
+	$(ECHO) "$$debian_postrm" > $(DEB_BUILD_DIR)/postrm
+	$(ECHO) "$$debian_control" > $(DEB_BUILD_DIR)/control
+	$(ECHO) 2.0 > $(DEB_BUILD_DIR)/debian-binary
+	
+	# create the "installed" file directory structure
+	$(MKDIR) -p $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+
+	$(CP) -rv $(BASE_INSTALL_DIR)/bin $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/include $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/lib $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/share $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(CP) -rv $(BASE_INSTALL_DIR)/libexec $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+
+	# wrapper script to set bcftools plugin environment variable
+	echo "$$bcftools_wrapper" > $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
+	chmod a+x $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
+	
+	# create the underlying tars of the debian package
+	$(TAR) cvzf $(DEB_BUILD_DIR)/data.tar.gz --owner=0 --group=0 -C $(DEB_BUILD_DIR) opt
+	$(TAR) cvzf $(DEB_BUILD_DIR)/control.tar.gz -C $(DEB_BUILD_DIR) control postrm
+	
+	# assemble the formal "deb" package
+	cd $(DEB_BUILD_DIR) && \
+		$(AR) rc $(DEB_PKG) debian-binary control.tar.gz data.tar.gz && \
+		$(MV) $(DEB_PKG) $(RELEASE_DIR)
+
+$(BCFTOOLS): $(BCFTOOLS_ZIP) $(TABIX) $(BGZIP)
+	$(TAR) -jxvf $(BCFTOOLS_ZIP) \
+		&& cd $(BCFTOOLS_OUTPUT_DIR) \
+		&& make all HTSDIR=$(HTSLIB_OUTPUT_DIR) prefix="$(BASE_INSTALL_DIR)" LIBS="-lcurl -lcrypto -lssl" \
+		&& make install HTSDIR=$(HTSLIB_OUTPUT_DIR) prefix="$(BASE_INSTALL_DIR)" LIBS="-lcurl -lcrypto -lssl" \
+		&& $(MV) $(BCFTOOLS) $(BCFTOOLS)-$(BCFTOOLS_VERSION)
+
+$(BCFTOOLS_ZIP):
+	mkdir -p $(RESOURCES_DIR)
+	cd $(RESOURCES_DIR) && \
+		$(CURL) -L -O $(BCFTOOLS_URL)
+
+$(TABIX) $(BGZIP): $(HTSLIB_ZIP)
+	$(TAR) -jxvf $(HTSLIB_ZIP) \
+		&& cd $(HTSLIB_OUTPUT_DIR) \
+		&& ./configure --enable-libcurl --prefix=$(BASE_INSTALL_DIR) \
+		&& make lib-static \
+		&& make install
+
+$(HTSLIB_ZIP):
+	mkdir -p $(RESOURCES_DIR)
+	cd $(RESOURCES_DIR) && \
+		$(CURL) -L -O $(HTSLIB_URL)
+
+debclean:
+	if [ -e $(DEB_BUILD_DIR) ]; then $(RM) -rf $(DEB_BUILD_DIR); fi
+	if [ -e $(DEB_PKG_PATH) ]; then $(RM) -rf $(DEB_PKG_PATH); fi
+
+clean:
+	if [ -e $(BCFTOOLS_OUTPUT_DIR) ]; then $(RM) -rf $(BCFTOOLS_OUTPUT_DIR); fi
+	if [ -e $(HTSLIB_OUTPUT_DIR) ]; then $(RM) -rf $(HTSLIB_OUTPUT_DIR); fi
+	if [ -e $(DEB_BUILD_DIR) ]; then $(RM) -rf $(DEB_BUILD_DIR); fi
+	if [ -e $(DEB_PKG_PATH) ]; then $(RM) -rf $(DEB_PKG_PATH); fi

--- a/bcftools-1.9/Makefile
+++ b/bcftools-1.9/Makefile
@@ -42,6 +42,7 @@ Section: science
 Maintainer: Indraniel Das <idas@wustl.edu>
 Priority: optional
 Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.0.2, hall-lab-htslib-1.9
+Suggests: texlive-base, hall-lab-python-2.7.15, hall-lab-python-2.7.15-matplotlib, hall-lab-perl-5.28.0
 Description: bcftools-$(BCFTOOLS_VERSION) for the Hall Lab 
 Version: $(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION)
 endef

--- a/bcftools-1.9/Makefile
+++ b/bcftools-1.9/Makefile
@@ -41,7 +41,7 @@ Architecture: amd64
 Section: science
 Maintainer: Indraniel Das <idas@wustl.edu>
 Priority: optional
-Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.0.2
+Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.0.2, hall-lab-htslib-1.9
 Description: bcftools-$(BCFTOOLS_VERSION) for the Hall Lab 
 Version: $(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION)
 endef

--- a/bcftools-1.9/Makefile
+++ b/bcftools-1.9/Makefile
@@ -24,14 +24,6 @@ BCFTOOLS_ZIP        := $(RESOURCES_DIR)/bcftools-$(BCFTOOLS_VERSION).tar.bz2
 BCFTOOLS_OUTPUT_DIR := $(WORK_DIR)/bcftools-$(BCFTOOLS_VERSION)
 BCFTOOLS            := $(WORK_DIR)/bin/bcftools
 
-# source code information
-HTSLIB_VERSION    := 1.9
-HTSLIB_URL        := https://github.com/samtools/htslib/releases/download/$(HTSLIB_VERSION)/htslib-$(HTSLIB_VERSION).tar.bz2
-HTSLIB_ZIP        := $(RESOURCES_DIR)/htslib-$(HTSLIB_VERSION).tar.bz2
-HTSLIB_OUTPUT_DIR := $(WORK_DIR)/htslib-$(HTSLIB_VERSION)
-TABIX             := $(WORK_DIR)/bin/tabix
-BGZIP             := $(WORK_DIR)/bin/bgzip
-
 # debian packaging related variables
 DEB_BUILD_DIR       := $(WORK_DIR)/deb-build
 DEBIAN_EDITION      := $(shell cat /etc/debian_version)
@@ -47,8 +39,8 @@ Architecture: amd64
 Section: science
 Maintainer: Indraniel Das <idas@wustl.edu>
 Priority: optional
-Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.1
-Description: bcftools-$(BCFTOOLS_VERSION) plus htslib-$(HTSLIB_VERSION) for the Hall Lab 
+Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.0.2
+Description: bcftools-$(BCFTOOLS_VERSION) for the Hall Lab 
 Version: $(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION)
 endef
 export debian_control
@@ -93,8 +85,6 @@ debian: | $(BCFTOOLS)
 	$(MKDIR) -p $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
 
 	$(CP) -rv $(BASE_INSTALL_DIR)/bin $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
-	$(CP) -rv $(BASE_INSTALL_DIR)/include $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
-	$(CP) -rv $(BASE_INSTALL_DIR)/lib $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
 	$(CP) -rv $(BASE_INSTALL_DIR)/share $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
 	$(CP) -rv $(BASE_INSTALL_DIR)/libexec $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
 
@@ -111,29 +101,17 @@ debian: | $(BCFTOOLS)
 		$(AR) rc $(DEB_PKG) debian-binary control.tar.gz data.tar.gz && \
 		$(MV) $(DEB_PKG) $(RELEASE_DIR)
 
-$(BCFTOOLS): $(BCFTOOLS_ZIP) $(TABIX) $(BGZIP)
+$(BCFTOOLS): $(BCFTOOLS_ZIP)
 	$(TAR) -jxvf $(BCFTOOLS_ZIP) \
 		&& cd $(BCFTOOLS_OUTPUT_DIR) \
-		&& make all HTSDIR=$(HTSLIB_OUTPUT_DIR) prefix="$(BASE_INSTALL_DIR)" LIBS="-lcurl -lcrypto -lssl" \
-		&& make install HTSDIR=$(HTSLIB_OUTPUT_DIR) prefix="$(BASE_INSTALL_DIR)" LIBS="-lcurl -lcrypto -lssl" \
+		&& ./configure --with-htslib=/opt/hall-lab/htslib-${BCFTOOLS_VERSION} --prefix="$(BASE_INSTALL_DIR)" \
+		&& make install \
 		&& $(MV) $(BCFTOOLS) $(BCFTOOLS)-$(BCFTOOLS_VERSION)
 
 $(BCFTOOLS_ZIP):
 	mkdir -p $(RESOURCES_DIR)
 	cd $(RESOURCES_DIR) && \
 		$(CURL) -L -O $(BCFTOOLS_URL)
-
-$(TABIX) $(BGZIP): $(HTSLIB_ZIP)
-	$(TAR) -jxvf $(HTSLIB_ZIP) \
-		&& cd $(HTSLIB_OUTPUT_DIR) \
-		&& ./configure --enable-libcurl --prefix=$(BASE_INSTALL_DIR) \
-		&& make lib-static \
-		&& make install
-
-$(HTSLIB_ZIP):
-	mkdir -p $(RESOURCES_DIR)
-	cd $(RESOURCES_DIR) && \
-		$(CURL) -L -O $(HTSLIB_URL)
 
 debclean:
 	if [ -e $(DEB_BUILD_DIR) ]; then $(RM) -rf $(DEB_BUILD_DIR); fi

--- a/bcftools-1.9/Makefile
+++ b/bcftools-1.9/Makefile
@@ -31,6 +31,8 @@ DEB_RELEASE_VERSION := 1debian$(DEBIAN_EDITION)
 DEB_PKG             := hall-lab-bcftools-$(BCFTOOLS_VERSION)_$(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION).deb
 DEB_PKG_PATH        := $(RELEASE_DIR)/$(DEB_PKG)
 DEB_BASE_INSTALL    := /opt/hall-lab/bcftools-$(BCFTOOLS_VERSION)
+DEBIAN_PROFILE_DIR  := /etc/profile.d
+BCFTOOLS_PROFILE    := $(DEBIAN_PROFILE_DIR)/hall-lab-bcftools.sh
 
 # DEBIAN CONTROL FILE ##########################################################
 define debian_control
@@ -50,13 +52,26 @@ define debian_postrm
 #!/bin/bash
 
 BASE=$(DEB_BASE_INSTALL)
+PROFILE_SCRIPT=$(BCFTOOLS_PROFILE)
 
 if [ -e $${BASE} ]; then
     $(RM) -rfv $${BASE}
 fi
 
+if [ -e $${PROFILE_SCRIPT} ]; then
+	$(RM) -fv $${PROFILE_SCRIPT}
+fi
+
 endef
 export debian_postrm
+
+# BCFTOOLS PATH CONFIGURATION ###########################################################
+define bcftools_path_set
+#!/bin/bash
+
+PATH=${DEB_BASE_INSTALL}/bin:$$PATH
+endef
+export bcftools_path_set
 
 # BCFTOOLS EXECUTABLE DEBIAN WRAPPER ###########################################################
 define bcftools_wrapper
@@ -83,6 +98,7 @@ debian: | $(BCFTOOLS)
 	
 	# create the "installed" file directory structure
 	$(MKDIR) -p $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
+	$(MKDIR) -p $(DEB_BUILD_DIR)/$(DEBIAN_PROFILE_DIR)
 
 	$(CP) -rv $(BASE_INSTALL_DIR)/bin $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
 	$(CP) -rv $(BASE_INSTALL_DIR)/share $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
@@ -91,9 +107,12 @@ debian: | $(BCFTOOLS)
 	# wrapper script to set bcftools plugin environment variable
 	echo "$$bcftools_wrapper" > $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
 	chmod a+x $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
+
+	# add hall-lab bcftools path for all users in login shells
+	echo "$$bcftools_path_set" > ${DEB_BUILD_DIR}/$(BCFTOOLS_PROFILE)
 	
 	# create the underlying tars of the debian package
-	$(TAR) cvzf $(DEB_BUILD_DIR)/data.tar.gz --owner=0 --group=0 -C $(DEB_BUILD_DIR) opt
+	$(TAR) cvzf $(DEB_BUILD_DIR)/data.tar.gz --owner=0 --group=0 -C $(DEB_BUILD_DIR) opt etc
 	$(TAR) cvzf $(DEB_BUILD_DIR)/control.tar.gz -C $(DEB_BUILD_DIR) control postrm
 	
 	# assemble the formal "deb" package

--- a/bcftools-1.9/Makefile
+++ b/bcftools-1.9/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean debian debclean
+.PHONY: clean debian debian-build debclean
 
 # external commands used
 CURL  := /usr/bin/curl
@@ -31,18 +31,15 @@ DEB_RELEASE_VERSION := 1debian$(DEBIAN_EDITION)
 DEB_PKG             := hall-lab-bcftools-$(BCFTOOLS_VERSION)_$(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION).deb
 DEB_PKG_PATH        := $(RELEASE_DIR)/$(DEB_PKG)
 DEB_BASE_INSTALL    := /opt/hall-lab/bcftools-$(BCFTOOLS_VERSION)
-DEBIAN_PROFILE_DIR  := /etc/profile.d
-BCFTOOLS_PROFILE    := $(DEBIAN_PROFILE_DIR)/hall-lab-bcftools.sh
 
 # DEBIAN CONTROL FILE ##########################################################
 define debian_control
 Package: hall-lab-bcftools-$(BCFTOOLS_VERSION)
 Architecture: amd64
 Section: science
-Maintainer: Indraniel Das <idas@wustl.edu>
+Maintainer: Dave Larson <delarson@wustl.edu>
 Priority: optional
-Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.0.2, hall-lab-htslib-1.9
-Suggests: texlive-base, hall-lab-python-2.7.15, hall-lab-python-2.7.15-matplotlib, hall-lab-perl-5.28.0
+Depends: libc6, libcurl3, zlib1g, ca-certificates, libbz2-1.0, liblzma5, libssl1.0.2
 Description: bcftools-$(BCFTOOLS_VERSION) for the Hall Lab 
 Version: $(BCFTOOLS_VERSION)-$(DEB_RELEASE_VERSION)
 endef
@@ -53,26 +50,13 @@ define debian_postrm
 #!/bin/bash
 
 BASE=$(DEB_BASE_INSTALL)
-PROFILE_SCRIPT=$(BCFTOOLS_PROFILE)
 
 if [ -e $${BASE} ]; then
     $(RM) -rfv $${BASE}
 fi
 
-if [ -e $${PROFILE_SCRIPT} ]; then
-	$(RM) -fv $${PROFILE_SCRIPT}
-fi
-
 endef
 export debian_postrm
-
-# BCFTOOLS PATH CONFIGURATION ###########################################################
-define bcftools_path_set
-#!/bin/bash
-
-PATH=${DEB_BASE_INSTALL}/bin:$$PATH
-endef
-export bcftools_path_set
 
 # BCFTOOLS EXECUTABLE DEBIAN WRAPPER ###########################################################
 define bcftools_wrapper
@@ -88,7 +72,17 @@ export bcftools_wrapper
 
 all: debian
 
-debian: | $(BCFTOOLS)
+debian: debian-build
+	# create the underlying tars of the debian package
+	$(TAR) cvzf $(DEB_BUILD_DIR)/data.tar.gz --owner=0 --group=0 -C $(DEB_BUILD_DIR) opt
+	$(TAR) cvzf $(DEB_BUILD_DIR)/control.tar.gz -C $(DEB_BUILD_DIR) control postrm
+	
+	# assemble the formal "deb" package
+	cd $(DEB_BUILD_DIR) && \
+		$(AR) rc $(DEB_PKG) debian-binary control.tar.gz data.tar.gz && \
+		$(MV) $(DEB_PKG) $(RELEASE_DIR)
+
+debian-build: | $(BCFTOOLS)
 	# setup the directory
 	$(TEST) -d $(DEB_BUILD_DIR) || $(MKDIR) $(DEB_BUILD_DIR)
 	
@@ -99,7 +93,6 @@ debian: | $(BCFTOOLS)
 	
 	# create the "installed" file directory structure
 	$(MKDIR) -p $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
-	$(MKDIR) -p $(DEB_BUILD_DIR)/$(DEBIAN_PROFILE_DIR)
 
 	$(CP) -rv $(BASE_INSTALL_DIR)/bin $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
 	$(CP) -rv $(BASE_INSTALL_DIR)/share $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)
@@ -109,22 +102,10 @@ debian: | $(BCFTOOLS)
 	echo "$$bcftools_wrapper" > $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
 	chmod a+x $(DEB_BUILD_DIR)/$(DEB_BASE_INSTALL)/bin/bcftools
 
-	# add hall-lab bcftools path for all users in login shells
-	echo "$$bcftools_path_set" > ${DEB_BUILD_DIR}/$(BCFTOOLS_PROFILE)
-	
-	# create the underlying tars of the debian package
-	$(TAR) cvzf $(DEB_BUILD_DIR)/data.tar.gz --owner=0 --group=0 -C $(DEB_BUILD_DIR) opt etc
-	$(TAR) cvzf $(DEB_BUILD_DIR)/control.tar.gz -C $(DEB_BUILD_DIR) control postrm
-	
-	# assemble the formal "deb" package
-	cd $(DEB_BUILD_DIR) && \
-		$(AR) rc $(DEB_PKG) debian-binary control.tar.gz data.tar.gz && \
-		$(MV) $(DEB_PKG) $(RELEASE_DIR)
-
 $(BCFTOOLS): $(BCFTOOLS_ZIP)
 	$(TAR) -jxvf $(BCFTOOLS_ZIP) \
 		&& cd $(BCFTOOLS_OUTPUT_DIR) \
-		&& ./configure --with-htslib=/opt/hall-lab/htslib-${BCFTOOLS_VERSION} --prefix="$(BASE_INSTALL_DIR)" \
+		&& ./configure --enable-libcurl --with-libdeflate --prefix="$(BASE_INSTALL_DIR)" \
 		&& make install \
 		&& $(MV) $(BCFTOOLS) $(BCFTOOLS)-$(BCFTOOLS_VERSION)
 
@@ -139,6 +120,5 @@ debclean:
 
 clean:
 	if [ -e $(BCFTOOLS_OUTPUT_DIR) ]; then $(RM) -rf $(BCFTOOLS_OUTPUT_DIR); fi
-	if [ -e $(HTSLIB_OUTPUT_DIR) ]; then $(RM) -rf $(HTSLIB_OUTPUT_DIR); fi
 	if [ -e $(DEB_BUILD_DIR) ]; then $(RM) -rf $(DEB_BUILD_DIR); fi
 	if [ -e $(DEB_PKG_PATH) ]; then $(RM) -rf $(DEB_PKG_PATH); fi

--- a/bcftools-1.9/README.md
+++ b/bcftools-1.9/README.md
@@ -1,19 +1,19 @@
 # production mode
 
-    docker build -t bcftools-1.9:v1 .
-    docker run -i -t -v $PWD:/release --rm bcftools-1.9:v1
+    docker build -t bcftools-1.9-build:v1 .
+    docker run -i -t -v $PWD:/release --rm bcftools-1.9-build:v1
 
 # Development Mode
 
-comment out the "COPY" commands in the Dockerfile, and then run:
+comment out the "COPY" commands in the Dockerfile AND uncomment the VOLUME /build command, and then run:
 
-    docker build -t bcftools-1.9:v1 .
-    docker run -i -t -v $PWD:/build --rm bcftools-1.9:v1 bash
+    docker build -t bcftools-1.9-build:v1 .
+    docker run -i -t -v $PWD:/build --rm bcftools-1.9-build:v1 bash
 
 # Testing
 
-    docker build -t bcftools-1.9:v1 .
-    docker run -i -t -v $PWD:/release --rm bcftools-1.9:v1 bash
+    docker build -t bcftools-1.9-build:v1 .
+    docker run -i -t -v $PWD:/release --rm bcftools-1.9-build:v1 bash
 
     # inside the container
     cd /release

--- a/bcftools-1.9/README.md
+++ b/bcftools-1.9/README.md
@@ -1,0 +1,21 @@
+# production mode
+
+    docker build -t bcftools-1.9:v1 .
+    docker run -i -t -v $PWD:/release --rm bcftools-1.9:v1
+
+# Development Mode
+
+comment out the "COPY" commands in the Dockerfile, and then run:
+
+    docker build -t bcftools-1.9:v1 .
+    docker run -i -t -v $PWD:/build --rm bcftools-1.9:v1 bash
+
+# Testing
+
+    docker build -t bcftools-1.9:v1 .
+    docker run -i -t -v $PWD:/release --rm bcftools-1.9:v1 bash
+
+    # inside the container
+    cd /release
+    # manually install the prerequisites for the package
+    dpkg --install hall-lab-bcftools-1.9_1.9-1debian9.5.deb


### PR DESCRIPTION
This still needs latex and other dependencies for plot-vcfstats as well as a location from which to pull hall-lab-htslib which is another dependency.

Let me know how you feel about adding hall-lab-bcftools to the path automatically for login shells.